### PR TITLE
"Stateless" Ziria Semantics

### DIFF
--- a/Coq/ZirStepper.v
+++ b/Coq/ZirStepper.v
@@ -1,0 +1,250 @@
+Set Implicit Arguments.
+
+Section Zir.
+
+Variables S I O V : Type.
+
+Inductive Zir :=
+  | Yield : S -> O -> Zir
+  | Skip : S -> Zir
+  | Done : V -> Zir
+  | NeedInput : (I -> S) -> Zir.
+
+End Zir.
+
+Arguments Yield [S I O V] _ _.
+Arguments Skip [S I O V] _.
+Arguments Done [S I O V] _.
+Arguments NeedInput [S I O V] _.
+
+Section Cast.
+
+Variables S S' I O V : Type.
+
+Definition cast (f : S -> S') (z : Zir S I O V) : Zir S' I O V :=
+  match z with
+    | Yield s out_val => Yield (f s) out_val
+    | Skip s => Skip (f s)
+    | Done val => Done val
+    | NeedInput g => NeedInput (fun s => f (g s))
+  end.
+
+End Cast.                     
+
+Section SZir.
+
+Variables S I O V : Type.
+
+(* NOTE: no existential state! 
+
+   Existentially quantifying the state-type S in the definition of 'SZir', as 
+   in the Haskell code, leads to a universe inconsistency in the definition 
+   of 'zbind'. See [NOTE: EXISTENTIAL] below.
+*)
+
+Inductive SZir :=
+  mkSZir : S -> (S -> Zir S I O V) -> SZir.
+
+End SZir.
+
+(* (* [NOTE: EXISTENTIAL] The following code hides the state type in 'SZir', but 
+   this formulation leads to a universe inconsistency in the definition of 'zbind'. *)
+
+Section SZir.
+
+Variables I O V : Type.
+
+Inductive SZir :=
+  mkSZir : forall S : Type, S -> (S -> Zir S I O V) -> SZir.
+
+(* An isomorphic alternative definition:
+Definition SZir := {S : Type & (S * (S -> Zir S I O V))%type}.
+
+Definition mkSZir (S : Type) (s : S) (f : S -> Zir S I O V) : SZir := @existT _ _ S (s, f).
+
+Definition type_of  (z : SZir) : Type := projT1 z.
+Definition state_of (z : SZir) : type_of z := fst (projT2 z).
+Definition sfun_of  (z : SZir) : type_of z -> Zir (type_of z) I O V := snd (projT2 z).
+*)
+
+End SZir.
+
+Section Bind.
+
+Variables I O V : Type.
+
+Definition zbind (z1 : SZir I O V) (f : V -> SZir I O V) : SZir I O V :=
+  match z1 with
+    | mkSZir _ s1 step1 => 
+      mkSZir (inl s1) (fun e => 
+        match e with
+          | inl s1 => 
+            match step1 s1 with
+              | Skip s1' => Skip (inl s1')
+              | Done val => 
+                  match f val with
+                    | mkSZir _ s2 step2 => 
+                        cast (fun x => inr (mkSZir x step2)) (step2 s2)
+                  end
+              | Yield s1' out_val => Yield (inl s1') out_val
+              | NeedInput h => NeedInput (fun in_val => inl (h in_val))
+            end
+          | inr sec => 
+              match sec with
+                | mkSZir _ s2 step2 => 
+                  cast (fun x => inr (mkSZir x step2)) (step2 s2)
+              end
+        end)
+  end.
+
+(* Alternative zbind, for the isomorphic 'SZir' type. Also leads to UC. *)
+Definition zbind (z1 : SZir I O V) (f : V -> SZir I O V) : SZir I O V :=
+  let s1 := state_of z1 in
+  let step1 := sfun_of z1 in 
+    mkSZir (inl s1) (fun e => 
+      match e with
+        | inl s1 => 
+            match step1 s1 with
+              | Skip s1' => Skip (inl s1')
+              | Done val => 
+                  let s2 := state_of (f val) in
+                  let step2 := sfun_of (f val) in 
+                    cast (fun x => inr (mkSZir x step2)) (step2 s2)
+              | Yield s1' out_val => Yield (inl s1') out_val
+              | NeedInput h => NeedInput (fun in_val => inl (h in_val))
+            end
+        | inr sec => 
+            let s2 := state_of sec in
+            let step2 := sfun_of sec in
+              cast (fun x => inr (mkSZir x step2)) (step2 s2)
+      end).
+*)
+
+Section EmitTakeReturn.
+
+Variables I O V : Type.
+
+Definition zemit (out_val : O) : SZir bool I O unit :=
+  mkSZir true (fun b : bool => if b then Yield false out_val
+                               else Done tt).
+
+Definition ztake : SZir (option I) I O I :=
+  mkSZir None (fun mv : option I => 
+                 match mv with
+                   | None => NeedInput (fun in_val => Some in_val)
+                   | Some in_val => Done in_val
+                 end).
+
+Definition zreturn (val : V) : SZir unit I O V :=
+  mkSZir tt (fun u : unit => Done val).
+
+End EmitTakeReturn.
+
+Section Bind.
+
+Variables S1 S2 I O V1 V2 : Type.
+
+Definition zbind (z1 : SZir S1 I O V1) (f : V1 -> SZir S2 I O V2) 
+  : SZir (S1 + SZir S2 I O V2) I O V2 :=
+  match z1 with
+    | mkSZir s1 step1 => 
+      mkSZir (inl s1) (fun e => 
+        match e with
+          | inl s1 => 
+            match step1 s1 with
+              | Skip s1' => Skip (inl s1')
+              | Done val => 
+                  match f val with
+                    | mkSZir s2 step2 => 
+                        cast (fun x => inr (mkSZir x step2)) (step2 s2)
+                  end
+              | Yield s1' out_val => Yield (inl s1') out_val
+              | NeedInput h => NeedInput (fun in_val => inl (h in_val))
+            end
+          | inr sec => 
+              match sec with
+                | mkSZir s2 step2 => 
+                  cast (fun x => inr (mkSZir x step2)) (step2 s2)
+              end
+        end)
+  end.
+
+End Bind.
+
+Section Pipe.
+
+Variables S1 S2 I M O V : Type.
+
+Definition zpipe (z1 : SZir S1 I M V) (z2 : SZir S2 M O V) : SZir (S1*S2) I O V :=
+  match z1, z2 with
+    | mkSZir s1 step1, mkSZir s2 step2 => 
+      mkSZir (s1,s2) (fun p => 
+        let (s1,s2) := p in 
+          match step2 s2 with
+            | Yield s2' out_val => Yield (s1,s2') out_val
+            | Skip s2' => Skip (s1, s2')
+            | Done val => Done val
+            | NeedInput g2 => 
+                match step1 s1 with
+                  | Yield s1' m => Skip (s1', g2 m)
+                  | Skip s1' => Skip (s1', s2)
+                  | Done val => Done val
+                  | NeedInput g1 => NeedInput (fun in_val => (g1 in_val, s2))
+                end
+          end)
+  end.
+
+End Pipe.
+
+Require Import List.
+
+Section Run.
+
+Variables State I O V : Type.
+
+Inductive Err : Type :=
+| raiseOutOfFuel : Err
+| raiseNeedInput : Err.
+
+Definition Result : Type := (list O * ((list I * Err) + V))%type.
+
+Fixpoint loop (fuel : nat) (acc : list O) (step : State -> Zir State I O V) 
+              (in_vals : list I) (z : Zir State I O V) : Result :=
+  match fuel with
+    | 0 => (rev acc, inl (in_vals, raiseOutOfFuel))
+    | S fuel' => 
+      match z with
+        | Yield s' out_val => loop fuel' (out_val :: acc) step in_vals (step s')
+        | Skip s' => loop fuel' acc step in_vals (step s')
+        | Done val => (rev acc, inr val)
+        | NeedInput g => 
+          match in_vals with
+            | nil => (rev acc, inl (in_vals, raiseNeedInput))
+            | i :: in_vals' => loop fuel' acc step in_vals' (step (g i))
+          end
+      end
+  end.
+
+Definition run (in_vals : list I) (z : SZir State I O V) : Result :=
+  match z with
+    | mkSZir s step => loop 1000 nil step in_vals (step s)
+  end. 
+
+End Run.
+
+Arguments ztake [I O].
+Arguments zemit [I O] out_val.
+Arguments zbind [S1 S2 I O V1 V2] z1 f.
+
+Definition test1 := zbind ztake (@zemit nat _).
+
+Definition test2 := zbind test1 (fun _ => test1).
+
+Definition test3 := zbind test1 (fun _ => test2).
+
+Definition test4 := zbind test1 (fun _ => test3).
+
+Eval compute in run (1::2::3::nil) test1.
+Eval compute in run (1::2::3::nil) test2.
+Eval compute in run (1::2::3::nil) test3.
+Eval compute in run (1::2::3::nil) test4. (*Err: needs input*)

--- a/Haskell/ZirPar.hs
+++ b/Haskell/ZirPar.hs
@@ -1,0 +1,148 @@
+module ZirPar where
+
+import Control.Concurrent.STM
+import Control.Concurrent.STM.TChan
+
+rw :: TChan a -> TChan a -> STM ()
+rw ch_in ch_out
+  = do { ma <- tryReadTChan ch_in
+       ; case ma of
+           Nothing -> return ()
+           Just a -> writeTChan ch_out a
+       }
+    
+forever :: STM u -> STM u
+forever f = f >> forever f
+
+mux :: TChan v -> TChan a -> TChan a -> TChan a -> STM ()
+mux ctl as1 as2 out_chan = go ctl as1 as2 out_chan
+  where go ctl as1 as2 out_chan
+          = do { mswitch  <- tryReadTChan ctl
+               ; case mswitch of
+                   Nothing -> rw as1 out_chan 
+                   Just _  -> rw as2 out_chan 
+               }
+                      
+dup :: TChan a -> STM (TChan a,TChan a)
+dup as
+  = do { as' <- cloneTChan as
+       ; return (as,as')
+       }
+
+newtype Zir a b v = Zir { unZir :: TChan a -> TChan b -> TChan v -> STM () }
+
+ztake :: Zir a b a
+ztake = Zir go
+  where go as bs ctl = rw as ctl >> return ()
+
+zemit :: b -> Zir a b ()
+zemit b = Zir go
+  where go as bs ctl
+          = do { writeTChan bs b
+               ; writeTChan ctl ()
+               }
+
+zbind :: Zir a b v1 -> (v1 -> Zir a b v2) -> Zir a b v2
+zbind z1 f = Zir go
+  where go as bs ctl
+          = do { let (as1,as2) = (as,as)
+               ; bs1 <- newTChan
+               ; bs2 <- newTChan
+               ; priv_ctl <- newTChan
+               ; (z2_start,mux_switch) <- dup priv_ctl
+               ; unZir z1 as1 bs1 z2_start
+               ; go2 z2_start as2 bs2 ctl
+               ; mux mux_switch bs1 bs2 bs
+               }
+        go2 start as0 bs0 ctl0
+          = do { mv1 <- tryReadTChan start
+               ; case mv1 of
+                   Nothing -> return ()
+                   Just v1 -> unZir (f v1) as0 bs0 ctl0
+               }
+
+zpipe :: Zir a b v -> Zir b c v -> Zir a c v
+zpipe z1 z2 = Zir go
+  where go as cs ctl
+          = do { bs <- newTChan 
+               ; unZir z1 as bs ctl
+               ; unZir z2 bs cs ctl
+               }
+    
+test_emit_take
+  = do { a0 <- newTChan
+       ; a <- newTChan
+       ; b <- newTChan
+       ; c0 <- newTChan              
+       ; c <- newTChan
+       ; unZir (zemit 2) a0 a c0
+       ; unZir ztake a b c
+       ; tryReadTChan c
+       }
+
+test_mux
+  = do { in_chan1 <- newTChan
+       ; in_chan2 <- newTChan
+       ; ctl_chan <- newTChan
+       ; out_chan <- newTChan                     
+       ; writeTChan in_chan1 1
+       ; mux in_chan1 in_chan2 ctl_chan out_chan
+       ; tryReadTChan out_chan
+       }
+
+zmap f = zbind ztake (\v -> zemit (f v))
+
+zinc = zmap (+ 1)
+
+zdouble = zinc `zpipe` zinc
+
+test_bind
+  = do { in_chan <- newTChan
+       ; out_chan <- newTChan
+       ; ctl_chan <- newTChan
+       ; writeTChan in_chan 1
+       ; unZir zinc in_chan out_chan ctl_chan
+       ; tryReadTChan out_chan
+       }
+
+test_pipe
+  = do { in_chan <- newTChan
+       ; out_chan <- newTChan
+       ; ctl_chan <- newTChan
+       ; writeTChan in_chan 1
+       ; unZir zdouble in_chan out_chan ctl_chan
+       ; tryReadTChan out_chan
+       }
+
+zsum
+  = zbind ztake (\v1 ->
+      zbind ztake (\v2 ->
+        zemit (v1 + v2)))
+
+test_sum
+  = do { in_chan <- newTChan
+       ; out_chan <- newTChan
+       ; ctl_chan <- newTChan
+       ; writeTChan in_chan 20
+       ; writeTChan in_chan 22
+       ; unZir zsum in_chan out_chan ctl_chan
+       ; tryReadTChan out_chan
+       }
+
+zsum_and_square
+  = zbind ztake (\v1 ->
+      zbind ztake (\v2 ->
+        zemit (v1 + v2)
+        `zpipe` zbind ztake (\v3 -> zemit (v3 * v3))))
+
+test_sum_and_square
+  = do { in_chan <- newTChan
+       ; out_chan <- newTChan
+       ; ctl_chan <- newTChan
+       ; writeTChan in_chan 20
+       ; writeTChan in_chan 22
+       ; unZir zsum_and_square in_chan out_chan ctl_chan
+       ; tryReadTChan out_chan
+       }
+
+

--- a/Haskell/ZirPar.hs
+++ b/Haskell/ZirPar.hs
@@ -1,15 +1,174 @@
-module ZirPar where
+module Main where
 
 import Control.Concurrent
 import Control.Concurrent.STM
 import Control.Concurrent.STM.TChan
 
-copy_one :: TChan a -> TChan a -> STM ()
+-----------------------------------------------------------------
+-- An alternative "stateless" Ziria semantics
+--
+-- The main idea is to make a distinction, on the one hand, between
+-- (a) the graph of a Ziria computation, which is just a static
+-- description of the program's dataflow, together with some
+-- control-flow constraints, and (b) the execution model, which is a
+-- particular (dynamic) scheduling strategy for executing the nodes of
+-- (a).
+-- 
+-- Below is a draft implementation of (a) in which all nodes in the
+-- dataflow graph run concurrently. I think it's possible to view the
+-- previous tick-process execution model as a particular dynamic
+-- scheduling policy applied to this "soup-of-nodes".  Note that,
+-- while I use the term "dataflow graph", there is actually some
+-- control flow hidden inside the implementation of `zbind', in the
+-- form of a set of control-flow constraints: When we `zbind z1 f',
+-- 'f' must block on the private control channel between `z1' and
+-- itself before proceeding.
+--
+-- NOTE that the soup-of-nodes model has the same problems (wrt.
+-- parallel pipe-in-bind, etc.) as the tick-process model. See the
+-- comment near 'test_pipe_in_bind' below for more discussion.  This
+-- file might be a good place to explore possible solutions, but I
+-- haven't yet done so.
+--
+-----------------------------------------------------------------
+
+-- Used to register the threads that are forked as the dataflow graph
+-- is unfolded
+type Children = MVar [MVar ()]
+
+newtype Zir a b v = Zir { unZir :: -- Special parameter:
+                                   Children -- A handle to a global list of forked threads
+
+                                   -- Main parameters: 
+                                -> TChan a  -- Input channel
+                                -> TChan b  -- Output channel
+                                -> TChan v  -- Control channel
+
+                                   -- Producing an IO action
+                                -> IO ()
+                        }
+
+ztake :: Zir a b a
+ztake = Zir go
+  where go _ as bs ctl = copy_one as ctl
+
+zemit :: b -> Zir a b ()
+zemit b = Zir go
+  where go _ as bs ctl
+          = do { atomically $ writeTChan bs b
+               ; atomically $ writeTChan ctl ()
+               }
+
+
+{-
+'zbind z1 (\v -> z2)' is modeled as the dataflow graph that looks
+like:
+              |-------|
+         /----|   z1  |----\
+        /     |_______|     \
+ a ----/          |          \-----> b
+       \          | v        / 
+        \     |---v---|     /
+         \____|   z2  |____/
+              |_______|
+
+where 'a' and 'b' are streams of input/output values and 'v' is the
+(private) control channel between 'z1' and 'z2'. 'z2' blocks until the
+control channel 'v' is nonempty.
+-}
+
+zbind :: Zir a b v1 -> (v1 -> Zir a b v2) -> Zir a b v2
+zbind z1 f = Zir go
+  where go children as bs ctl
+          = do { -- A private control channel between 'z1' and 'f'
+                 z1_done <- newTChanIO 
+                 -- Fork z1
+               ; forkChild children $ unZir z1 children as bs z1_done
+                 -- Fork f, but block until z1 sends a control value
+               ; forkChild children $ unZir (block_on z1_done f) children as bs ctl
+                 -- No need to join here, we're just unfolding the graph...
+               ; return ()
+               }
+
+-- Pipe just forks the two Zir computations 'z1' and 'z2'
+zpipe :: Zir a b v -> Zir b c v -> Zir a c v
+zpipe z1 z2 = Zir go
+  where go children as cs ctl
+          = do { bs <- newTChanIO
+               ; forkChild children $ unZir z1 children as bs ctl
+               ; forkChild children $ unZir z2 children bs cs ctl
+               ; return ()
+               }
+
+zrepeat :: Zir a b v -> Zir a b ()
+zrepeat z = zbind z (\_ -> zrepeat z)
+        
+zmap f = zrepeat $ zbind ztake (\v -> zemit (f v))
+
+test_zir :: Show b => Zir a b v -> [a] -> IO ()
+test_zir z as 
+  = do { in_chan <- newTChanIO
+       ; out_chan <- newTChanIO
+       ; ctl_chan <- newTChanIO
+       ; children <- newMVar []
+       ; write_to in_chan as
+       ; forkChild children $ unZir z children in_chan out_chan ctl_chan
+       ; forkChild children $ forever $ print_one out_chan
+       ; waitForChildren children
+       }
+  where write_to ch [] = return ()
+        write_to ch (v : vs)
+          = do { atomically $ writeTChan ch v
+               ; write_to ch vs
+               }
+
+zinc = zmap (+ 1)
+zsum = zrepeat $ zbind ztake (\v1 -> zbind ztake (\v2 -> zemit (v1 + v2)))
+
+-- Tests may not terminate; zmap, etc., produces nodes that zrepeat.
+test_bind  = test_zir zinc [1..10]
+test_pipe  = test_zir ((zpipe zinc zinc) `zpipe` (zpipe zinc zinc)) [1..10]
+test_zsum  = test_zir zsum [1..10]
+
+main = test_zir ((zinc `zpipe` zinc) `zpipe` zsum `zpipe` (zinc `zpipe` zinc)) [1..10]
+
+-- The following program may produce result '4 5' (though I haven't
+-- yet observed it) due to a pipe-bind race condition (I think the
+-- same one that makes an appearance in parpipe-in-bind in the
+-- tick-process execution model):
+
+-- When (zemit 0) sends () on the private control channel sitting
+-- between (zemit 0 `zpipe` zemit 5) and (zemit 4), it does not
+-- synchronize with (zemit 5), which therefore continues to execute,
+-- possibly writing 5 to the output channel after (zemit 4) has
+-- written 4. My feeling is that pipe-in-bind is a general problem,
+-- even with the tick-process model, and probably orthogonal to the
+-- particular choice of execution model.
+--
+-- It's possible to prevent the race condition from occurring by
+-- introducing extra synchronizations (before (zemit 5) does anything
+-- observable, e.g., writing 5 to the output channel, make it check
+-- that (zemit 0) hasn't yet signalled). However, the extra
+-- synchronizations probably incur a performance pernalty.
+--
+-- ALSO: none of what's done in this file deals with the related
+-- mismatched-inputs problem, in which one component reads more from
+-- the input stream than it should have, causing a later-bound
+-- component from skipping some of its inputs.
+test_pipe_in_bind
+  = test_zir (zbind (zemit 0 `zpipe` zemit 5) (\_ -> zemit 4)) [1..5]
+
+
+-----------------------------------------------------------------
+--
+-- Auxiliary functions for programming concurrency
+--
+-----------------------------------------------------------------
+
+copy_one :: TChan a -> TChan a -> IO ()
 copy_one ch_in ch_out
-  = do { ma <- tryReadTChan ch_in
-       ; case ma of
-           Nothing -> return ()
-           Just a -> writeTChan ch_out a
+  = do { a <- atomically $ readTChan ch_in
+       ; atomically $ writeTChan ch_out a
        }
 
 forever :: IO a -> IO a
@@ -17,25 +176,10 @@ forever a = a >> forever a
 
 block_on :: TChan v1 -> (v1 ->  Zir a b v2) -> Zir a b v2
 block_on ch f = Zir go
-  where go as bs ctl 
-          = do { ma <- atomically $ tryReadTChan ch
-               ; case ma of
-                   Nothing -> unZir (block_on ch f) as bs ctl
-                   Just a  -> unZir (f a) as bs ctl
+  where go children as bs ctl 
+          = do { v <- atomically $ readTChan ch
+               ; unZir (f v) children as bs ctl
                }
-
-mux :: TChan v -> TChan a -> TChan a -> TChan a -> IO ()
-mux ctl_chan in_chan1 in_chan2 out_chan
-  = do { behave_as_chan2 <-
-            atomically
-            $ do { in_chan1_flushed <- isEmptyTChan in_chan1
-                 ; ctl_chan_empty   <- isEmptyTChan ctl_chan
-                 ; return $ in_chan1_flushed && not ctl_chan_empty
-                 }
-       ; atomically
-         $ if behave_as_chan2 then copy_one in_chan2 out_chan
-           else copy_one in_chan1 out_chan
-       }
 
 print_one ch
   = do { mv <- atomically $ tryReadTChan ch
@@ -63,102 +207,3 @@ waitForChildren children
                 ; waitForChildren children
                 }
        }
-
-test_mux
-  = do { in_chan1 <- newTChanIO
-       ; in_chan2 <- newTChanIO
-       ; ctl_chan <- newTChanIO
-       ; out_chan <- newTChanIO
-       ; children <- newMVar []
-       ; forkChild children
-         $ atomically $ do { writeTChan in_chan1 3; writeTChan ctl_chan () }
-       ; forkChild children $ atomically (writeTChan in_chan2 4)
-       ; forkChild children $ forever $ mux ctl_chan in_chan1 in_chan2 out_chan
-       ; forkChild children $ forever $ print_one out_chan
-       ; waitForChildren children
-       }
-
-dup :: TChan a -> STM (TChan a,TChan a)
-dup as
-  = do { as' <- cloneTChan as
-       ; return (as,as')
-       }
-
-newtype Zir a b v = Zir { unZir :: TChan a -> TChan b -> TChan v -> IO () }
-
-ztake :: Zir a b a
-ztake = Zir go
-  where go as bs ctl = atomically (copy_one as ctl) >> return ()
-
-zemit :: b -> Zir a b ()
-zemit b = Zir go
-  where go as bs ctl
-          = atomically 
-            $ do { writeTChan bs b
-                 ; writeTChan ctl ()
-                 }
-
-zbind :: Zir a b v1 -> (v1 -> Zir a b v2) -> Zir a b v2
-zbind z1 f = Zir go
-  where go as bs ctl
-          = do { bs1 <- newTChanIO
-               ; bs2 <- newTChanIO
-               ; new_ctl <- newTChanIO
-               ; (z1_done,mux_switch) <- atomically $ dup new_ctl
-               ; children <- newMVar []
-               ; forkChild children $ unZir z1 as bs1 z1_done
-               ; forkChild children $ unZir (block_on z1_done f) as bs2 ctl
-               ; forkChild children $ mux mux_switch bs1 bs2 bs
-               ; waitForChildren children
-               }
-
-zpipe :: Zir a b v -> Zir b c v -> Zir a c v
-zpipe z1 z2 = Zir go
-  where go as cs ctl
-          = do { bs <- newTChanIO
-               ; children <- newMVar []
-               ; forkChild children $ unZir z1 as bs ctl
-               ; forkChild children $ unZir z2 bs cs ctl
-               ; waitForChildren children
-               }
-
-zrepeat :: Zir a b v -> Zir a b v
-zrepeat z@(Zir f) = Zir go
-  where go as bs ctl = forever $ f as bs ctl
-        
-zmap f = zrepeat $ zbind ztake (\v -> zemit (f v))
-
-test_zir :: Show b => Zir a b v -> [a] -> IO ()
-test_zir z as 
-  = do { in_chan <- newTChanIO
-       ; out_chan <- newTChanIO
-       ; ctl_chan <- newTChanIO
-       ; children <- newMVar []
-       ; write_to in_chan as
-       ; forkChild children $ unZir z in_chan out_chan ctl_chan
-       ; forkChild children $ forever $ print_one out_chan
-       ; waitForChildren children
-       }
-  where write_to ch [] = return ()
-        write_to ch (v : vs)
-          = do { atomically $ writeTChan ch v
-               ; write_to ch vs
-               }
-
-zinc = zmap (+ 1)
-
-test_bind = test_zir zinc [1,2,3]
-
-zid = zmap id
-
-zplus2 = zid `zpipe` zid
-
-test_pipe = test_zir zplus2 [1,2,3]
-
-zsum2
-  = zrepeat
-    $ zbind ztake (\v1 ->
-        zbind ztake (\v2 ->
-          zemit (v1 + v2)))
-
-test_zsum2 = test_zir zsum2 [23,10]


### PR DESCRIPTION
The main idea is to make a distinction, on the one hand, between the graph of a Ziria computation, which is just a static description of the program's dataflow together with some control-flow constraints, and the execution model, which is a particular (dynamic) scheduling strategy for executing the graph.

This commit is a draft implementation of the above in which all nodes in the dataflow graph run concurrently. I think it's possible to view the previous tick-process execution model as a particular dynamic
scheduling policy applied to this "soup-of-nodes", but I haven't yet implemented this.

While I use the term "dataflow graph", there is actually some control flow hidden inside the implementation of `zbind`, in the form of a set of control-flow constraints: When we `zbind z1 f`,
`f` must blocking read on the private control channel between `z1` and itself before proceeding.

I believe the soup-of-nodes model has the same problems (wrt. parallel pipe-in-bind, etc.) as the tick-process model. See the comment near `test_pipe_in_bind` for more discussion.  This commit could serve as a starting point from which to explore possible solutions.
